### PR TITLE
Set up GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ round, and use the buttons to advance turns and phases.
 
 The winner is the player who completes all phases with the lowest total
 score.
+
+## Deployment
+
+This repository is configured to deploy the site using GitHub Pages. Any
+push to the `main` branch runs a workflow that publishes `index.html`
+so the scorecard is accessible as a public website.
+
+


### PR DESCRIPTION
## Summary
- deploy `index.html` using GitHub Pages
- document the GitHub Pages deployment
- update workflow to use non-deprecated actions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ff56b69a8832186db2fd72124943b